### PR TITLE
implements an `Invert Zoom` option

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -12,7 +12,7 @@ Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
     : QOpenGLWidget(parent), mesh(nullptr),
       scale(1), zoom(1), tilt(90), yaw(0),
       perspective(0.25), anim(this, "perspective"), status(" "),
-      meshInfo(""), drawMode(shaded), drawAxes(false)
+      meshInfo(""), drawMode(shaded), drawAxes(false), invertZoom(false)
 {
     setFormat(format);
     QFile styleFile(":/qt/style.qss");
@@ -59,6 +59,12 @@ void Canvas::draw_wireframe()
 void Canvas::draw_axes(bool d)
 {
     drawAxes = d;
+    update();
+}
+
+void Canvas::invert_zoom(bool d)
+{
+    invertZoom = d;
     update();
 }
 
@@ -275,12 +281,18 @@ void Canvas::wheelEvent(QWheelEvent *event)
     if (event->delta() < 0)
     {
         for (int i=0; i > event->delta(); --i)
-            zoom *= 1.001;
+            if (invertZoom)
+                zoom /= 1.001;
+            else 
+                zoom *= 1.001;
     }
     else if (event->delta() > 0)
     {
-        for (int i=0; i < event->delta(); ++i)
-            zoom /= 1.001;
+        for (int i=0; i < event->delta(); ++i) 
+            if (invertZoom) 
+                zoom *= 1.001;
+            else 
+                zoom /= 1.001;
     }
 
     // Then find the cursor's GL position post-zoom and adjust center.

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -25,6 +25,7 @@ public:
     void draw_shaded();
     void draw_wireframe();
     void draw_axes(bool d);
+    void invert_zoom(bool d);
 
 public slots:
     void set_status(const QString& s);
@@ -69,6 +70,7 @@ private:
     float perspective;
     enum DrawMode drawMode;
     bool drawAxes;
+    bool invertZoom;
     Q_PROPERTY(float perspective MEMBER perspective WRITE set_perspective);
     QPropertyAnimation anim;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -5,6 +5,7 @@
 #include "loader.h"
 
 const QString Window::RECENT_FILE_KEY = "recentFiles";
+const QString Window::INVERT_ZOOM_KEY = "invertZoom";
 
 Window::Window(QWidget *parent) :
     QMainWindow(parent),
@@ -121,7 +122,12 @@ Window::Window(QWidget *parent) :
     view_menu->addAction(invert_zoom_action);
     invert_zoom_action->setCheckable(true);
     QObject::connect(invert_zoom_action, &QAction::triggered,
-            this, &Window::on_invertZoom);        
+            this, &Window::on_invertZoom);       
+
+    QSettings settings;
+    bool invertZoomFromSettings = settings.value(INVERT_ZOOM_KEY, false).toBool();
+    canvas->invert_zoom(invertZoomFromSettings);
+    invert_zoom_action->setChecked(invertZoomFromSettings);
 
     auto help_menu = menuBar()->addMenu("Help");
     help_menu->addAction(about_action);
@@ -237,6 +243,8 @@ void Window::on_drawAxes(bool d)
 void Window::on_invertZoom(bool d)
 {
     canvas->invert_zoom(d);
+    QSettings settings;
+    settings.setValue(INVERT_ZOOM_KEY, d);
 }
 
 void Window::on_watched_change(const QString& filename)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -16,6 +16,7 @@ Window::Window(QWidget *parent) :
     shaded_action(new QAction("Shaded", this)),
     wireframe_action(new QAction("Wireframe", this)),
     axes_action(new QAction("Draw Axes", this)),
+    invert_zoom_action(new QAction("Invert Zoom", this)),
     reload_action(new QAction("Reload", this)),
     autoreload_action(new QAction("Autoreload", this)),
     save_screenshot_action(new QAction("Save Screenshot", this)),
@@ -116,6 +117,11 @@ Window::Window(QWidget *parent) :
     axes_action->setCheckable(true);
     QObject::connect(axes_action, &QAction::triggered,
             this, &Window::on_drawAxes);
+
+    view_menu->addAction(invert_zoom_action);
+    invert_zoom_action->setCheckable(true);
+    QObject::connect(invert_zoom_action, &QAction::triggered,
+            this, &Window::on_invertZoom);        
 
     auto help_menu = menuBar()->addMenu("Help");
     help_menu->addAction(about_action);
@@ -226,6 +232,11 @@ void Window::on_drawMode(QAction* mode)
 void Window::on_drawAxes(bool d)
 {
     canvas->draw_axes(d);
+}
+
+void Window::on_invertZoom(bool d)
+{
+    canvas->invert_zoom(d);
 }
 
 void Window::on_watched_change(const QString& filename)

--- a/src/window.h
+++ b/src/window.h
@@ -71,6 +71,7 @@ private:
     QAction* const recent_files_clear_action;
     const static int MAX_RECENT_FILES=8;
     const static QString RECENT_FILE_KEY;
+    const static QString INVERT_ZOOM_KEY;
     QString current_file;
     QString lookup_folder;
     QStringList lookup_folder_files;

--- a/src/window.h
+++ b/src/window.h
@@ -38,6 +38,7 @@ private slots:
     void on_projection(QAction* proj);
     void on_drawMode(QAction* mode);
     void on_drawAxes(bool d);
+    void on_invertZoom(bool d);
     void on_watched_change(const QString& filename);
     void on_reload();
     void on_autoreload_triggered(bool r);
@@ -60,6 +61,7 @@ private:
     QAction* const shaded_action;
     QAction* const wireframe_action;
     QAction* const axes_action;
+    QAction* const invert_zoom_action;
     QAction* const reload_action;
     QAction* const autoreload_action;
     QAction* const save_screenshot_action;


### PR DESCRIPTION
Hi, according to #41 I implemented an option point in the `View` menu to invert the zooming direction.

![image](https://user-images.githubusercontent.com/5106205/96284087-6add2900-0fdd-11eb-84de-608dab6367ce.png)

Only down side, it is not yet persistent, as - as far as I can see - there isn't yet a mechanism for storing configuration.