### PR TITLE
Versioning in app, other small changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.3)
 
+project(fstl)
+
 # Setting -std=c++11
 set(CMAKE_CXX_STANDARD 11)
 # Setting standard to required, as requisted by DeveloperPaul123 on github
@@ -12,10 +14,10 @@ set(CXX_STANDARD_REQUIRED ON)
 # Set the version number
 set (FSTL_VERSION_MAJOR "0")
 set (FSTL_VERSION_MINOR "9")
-set (FSTL_VERSION_PATCH "4")
+set (FSTL_VERSION_PATCH "5-snapshot")
 set (PROJECT_VERSION "${FSTL_VERSION_MAJOR}.${FSTL_VERSION_MINOR}.${FSTL_VERSION_PATCH}")
 
-project(fstl)
+message(STATUS "Version: ${PROJECT_VERSION}")
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -125,7 +127,7 @@ if(WIN32)
 	set(CPACK_NSIS_MUI_FINISHPAGE_RUN ${PROJECT_NAME})
 	set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}")
 	set(CPACK_NSIS_INSTALLED_ICON_NAME "bin\\\\fstl.exe")
-	set(CPACK_NSIS_URL_INFO_ABOUT "https://github.com/mkeeter/fstl")
+	set(CPACK_NSIS_URL_INFO_ABOUT "https://github.com/fstl-app/fstl")
 	set(CPACK_NSIS_DISPLAY_NAME "fstl ${FSTL_VERSION}")
 	set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/exe/fstl.ico")
 	set(CPACK_NSIS_MUI_UNIICON  "${CMAKE_CURRENT_SOURCE_DIR}/exe/fstl.ico")

--- a/README.md
+++ b/README.md
@@ -95,16 +95,13 @@ This should produce two new files in the root directory:
 Install Qt with your distro's package manager (required libraries are Core, Gui,
 Widgets and OpenGL, e.g. `qt5-default` and `libqt5opengl5-dev` on Debian).
 
-You can build fstl with qmake (in some distros qmake-qt5) or with CMake:
+You can build fstl with CMake:
 ```
 git clone https://github.com/mkeeter/fstl
 cd fstl
 mkdir build
 cd build
-
-qmake ../qt/fstl.pro  # For qmake build
-cmake ..              # For CMake build
-
+cmake ..
 make -j8
 ./fstl
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ making sure `qmake` is on your shell's path.
 Then, run through the following set of commands in a shell:
 
 ```
-git clone https://github.com/mkeeter/fstl
+git clone https://github.com/fstl-app/fstl
 cd fstl
 mkdir build
 cd build
@@ -97,7 +97,7 @@ Widgets and OpenGL, e.g. `qt5-default` and `libqt5opengl5-dev` on Debian).
 
 You can build fstl with CMake:
 ```
-git clone https://github.com/mkeeter/fstl
+git clone https://github.com/fstl-app/fstl
 cd fstl
 mkdir build
 cd build

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -24,9 +24,11 @@ Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
 
 Canvas::~Canvas()
 {
-	makeCurrent();
-	delete mesh;
-	doneCurrent();
+    makeCurrent();
+    delete mesh;
+    delete backdrop;
+    delete axis;
+    doneCurrent();
 }
 
 void Canvas::view_anim(float v)
@@ -70,6 +72,7 @@ void Canvas::invert_zoom(bool d)
 
 void Canvas::load_mesh(Mesh* m, bool is_reload)
 {
+    delete mesh;
     mesh = new GLMesh(m);
     QVector3D lower(m->xmin(), m->ymin(), m->zmin());
     QVector3D upper(m->xmax(), m->ymax(), m->zmax());

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -159,7 +159,7 @@ Mesh* Loader::read_stl_binary(QFile& file)
     QVector<Vertex> verts(tri_count*3);
 
     // Dummy array, because readRawData is faster than skipRawData
-    std::unique_ptr<uint8_t> buffer(new uint8_t[tri_count * 50]);
+    std::unique_ptr<uint8_t[]> buffer(new uint8_t[tri_count * 50]);
     data.readRawData((char*)buffer.get(), tri_count * 50);
 
     // Store vertices in the array, processing one triangle at a time.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,8 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("mkeeter");
     QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
     QCoreApplication::setApplicationName("fstl");
+    QCoreApplication::setApplicationVersion(FSTL_VERSION);
+    printf("Version: %s\n", FSTL_VERSION);
     App a(argc, argv);
     return a.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,6 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
     QCoreApplication::setApplicationName("fstl");
     QCoreApplication::setApplicationVersion(FSTL_VERSION);
-    printf("Version: %s\n", FSTL_VERSION);
     App a(argc, argv);
     return a.exec();
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -148,10 +148,10 @@ void Window::on_open()
 void Window::on_about()
 {
     QMessageBox::about(this, "",
-        "<p align=\"center\"><b>fstl</b></p>"
+        "<p align=\"center\"><b>fstl</b><br>" FSTL_VERSION "</p>"
         "<p>A fast viewer for <code>.stl</code> files.<br>"
-        "<a href=\"https://github.com/mkeeter/fstl\""
-        "   style=\"color: #93a1a1;\">https://github.com/mkeeter/fstl</a></p>"
+        "<a href=\"https://github.com/fstl-app/fstl\""
+        "   style=\"color: #93a1a1;\">https://github.com/fstl-app/fstl</a></p>"
         "<p>© 2014-2017 Matthew Keeter<br>"
         "<a href=\"mailto:matt.j.keeter@gmail.com\""
         "   style=\"color: #93a1a1;\">matt.j.keeter@gmail.com</a></p>");


### PR DESCRIPTION
Hi Everyone,
  This pull request addresses #63 (and changed version from 0.9.4 to 0.9.5-snapshot). With this new system, the next full release would be 0.9.5. I don't think this project has a standard for inter-release versioning, so this is just a suggestion/draft, and please feel free to let me know if you have other thoughts.
  In addition, it transitions some references from mkeeter/fstl to fstl-app/fstl. It also changes the linux build instructions to reflect the qmake changes made in #62. Finally, it addresses a couple memory management issues Valgrind found.
  I have only tested on 64bit linux qt5.15.2-1.
Thanks,
Martin