### PR TITLE
Fix build on Ubuntu 20.04 LTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(Icon_Resource exe/fstl.rc)
 set(OpenGL_GL_PREFERENCE GLVND)
 
 #find required packages. 
-find_package(Qt5 5.14 REQUIRED COMPONENTS Core Gui Widgets OpenGL)
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets OpenGL)
 find_package(OpenGL REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -278,23 +278,23 @@ void Canvas::wheelEvent(QWheelEvent *event)
 {
     // Find GL position before the zoom operation
     // (to zoom about mouse cursor)
-    auto p = event->position();
+    auto p = event->pos();
     QVector3D v(1 - p.x() / (0.5*width()),
                 p.y() / (0.5*height()) - 1, 0);
     QVector3D a = transform_matrix().inverted() *
                   view_matrix().inverted() * v;
 
-    if (event->angleDelta().y() < 0)
+    if (event->delta() < 0)
     {
-        for (int i=0; i > event->angleDelta().y(); --i)
+        for (int i=0; i > event->delta(); --i)
             if (invertZoom)
                 zoom /= 1.001;
             else 
                 zoom *= 1.001;
     }
-    else if (event->angleDelta().y() > 0)
+    else if (event->delta() > 0)
     {
-        for (int i=0; i < event->angleDelta().y(); ++i)
+        for (int i=0; i < event->delta(); ++i) 
             if (invertZoom) 
                 zoom *= 1.001;
             else 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -466,7 +466,7 @@ void Window::build_folder_file_list()
 QPair<QString, QString> Window::get_file_neighbors()
 {
     if (current_file.isEmpty()) {
-        return QPair<QString, QString>(QString(), QString());
+        return QPair<QString, QString>(QString::null, QString::null);
     }
 
     build_folder_file_list();
@@ -476,8 +476,8 @@ QPair<QString, QString> Window::get_file_neighbors()
     QString current_dir = fileInfo.absoluteDir().absolutePath();
     QString current_name = fileInfo.fileName();
 
-    QString prev = QString();
-    QString next = QString();
+    QString prev = QString::null;
+    QString next = QString::null;
 
     QListIterator<QString> fileIterator(lookup_folder_files);
     while (fileIterator.hasNext()) {


### PR DESCRIPTION
This reverts commit 18e0e5963fb85a575e21972d8179b48d94b5dce7.

20.04 LTS uses Qt 5.12, under which fstl previously would build fine. Since the referenced commit only fixed deprecation warnings, it can safely be reverted until a point in time when updating Qt becomes an actual requirement.

Fixes: #74 