### PR TITLE
Remember application settings

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -8,11 +8,14 @@
 #include "glmesh.h"
 #include "mesh.h"
 
+const float Canvas::P_PERSPECTIVE = 0.25f;
+const float Canvas::P_ORTHOGRAPHIC = 0.0f;
+
 Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
     : QOpenGLWidget(parent), mesh(nullptr),
       scale(1), zoom(1), tilt(90), yaw(0),
-      perspective(0.25), anim(this, "perspective"), status(" "),
-      meshInfo(""), drawMode(shaded), drawAxes(false), invertZoom(false)
+      anim(this, "perspective"), status(" "),
+      meshInfo("")
 {
     setFormat(format);
     QFile styleFile(":/qt/style.qss");
@@ -39,14 +42,15 @@ void Canvas::view_anim(float v)
     anim.start();
 }
 
-void Canvas::view_orthographic()
-{
-    view_anim(0);
-}
-
-void Canvas::view_perspective()
-{
-    view_anim(0.25);
+void Canvas::view_perspective(float p, bool animate){
+    if(animate)
+    {
+        view_anim(p);
+    }
+    else
+    {
+        set_perspective(p);
+    }
 }
 
 void Canvas::draw_axes(bool d)

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -10,7 +10,7 @@ class Mesh;
 class Backdrop;
 class Axis;
 
-enum DrawMode {shaded, wireframe, surfaceangle};
+enum DrawMode {shaded, wireframe, surfaceangle, DRAWMODECOUNT};
 
 class Canvas : public QOpenGLWidget, protected QOpenGLFunctions
 {
@@ -20,8 +20,10 @@ public:
     explicit Canvas(const QSurfaceFormat& format, QWidget* parent=0);
     ~Canvas();
 
-    void view_orthographic();
-    void view_perspective();
+    const static float P_PERSPECTIVE;
+    const static float P_ORTHOGRAPHIC;
+
+    void view_perspective(float p, bool animate);
     void draw_axes(bool d);
     void invert_zoom(bool d);
     void set_drawMode(enum DrawMode mode);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,8 @@
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setOrganizationName("mkeeter");
-    QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
+    QCoreApplication::setOrganizationName("fstl-app");
+    QCoreApplication::setOrganizationDomain("https://github.com/fstl-app/fstl");
     QCoreApplication::setApplicationName("fstl");
     QCoreApplication::setApplicationVersion(FSTL_VERSION);
     App a(argc, argv);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -6,6 +6,10 @@
 
 const QString Window::RECENT_FILE_KEY = "recentFiles";
 const QString Window::INVERT_ZOOM_KEY = "invertZoom";
+const QString Window::AUTORELOAD_KEY = "autoreload";
+const QString Window::DRAW_AXES_KEY = "drawAxes";
+const QString Window::PROJECTION_KEY = "projection";
+const QString Window::DRAW_MODE_KEY = "drawMode";
 
 Window::Window(QWidget *parent) :
     QMainWindow(parent),
@@ -13,7 +17,7 @@ Window::Window(QWidget *parent) :
     about_action(new QAction("About", this)),
     quit_action(new QAction("Quit", this)),
     perspective_action(new QAction("Perspective", this)),
-    orthogonal_action(new QAction("Orthographic", this)),
+    orthographic_action(new QAction("Orthographic", this)),
     shaded_action(new QAction("Shaded", this)),
     wireframe_action(new QAction("Wireframe", this)),
     surfaceangle_action(new QAction("Surface Angle", this)),
@@ -54,8 +58,6 @@ Window::Window(QWidget *parent) :
                      this, &Window::close);
 
     autoreload_action->setCheckable(true);
-    autoreload_action->setChecked(true);
-    autoreload_action->setEnabled(false);
     QObject::connect(autoreload_action, &QAction::triggered,
             this, &Window::on_autoreload_triggered);
 
@@ -90,14 +92,13 @@ Window::Window(QWidget *parent) :
     auto view_menu = menuBar()->addMenu("View");
     auto projection_menu = view_menu->addMenu("Projection");
     projection_menu->addAction(perspective_action);
-    projection_menu->addAction(orthogonal_action);
+    projection_menu->addAction(orthographic_action);
     auto projections = new QActionGroup(projection_menu);
-    for (auto p : {perspective_action, orthogonal_action})
+    for (auto p : {perspective_action, orthographic_action})
     {
         projections->addAction(p);
         p->setCheckable(true);
     }
-    perspective_action->setChecked(true);
     projections->setExclusive(true);
     QObject::connect(projections, &QActionGroup::triggered,
                      this, &Window::on_projection);
@@ -112,7 +113,6 @@ Window::Window(QWidget *parent) :
         drawModes->addAction(p);
         p->setCheckable(true);
     }
-    shaded_action->setChecked(true);
     drawModes->setExclusive(true);
     QObject::connect(drawModes, &QActionGroup::triggered,
                      this, &Window::on_drawMode);
@@ -126,15 +126,44 @@ Window::Window(QWidget *parent) :
     QObject::connect(invert_zoom_action, &QAction::triggered,
             this, &Window::on_invertZoom);       
 
-    QSettings settings;
-    bool invertZoomFromSettings = settings.value(INVERT_ZOOM_KEY, false).toBool();
-    canvas->invert_zoom(invertZoomFromSettings);
-    invert_zoom_action->setChecked(invertZoomFromSettings);
+    load_persist_settings();
 
     auto help_menu = menuBar()->addMenu("Help");
     help_menu->addAction(about_action);
 
     resize(600, 400);
+}
+
+void Window::load_persist_settings(){
+    QSettings settings;
+    bool invert_zoom = settings.value(INVERT_ZOOM_KEY, false).toBool();
+    canvas->invert_zoom(invert_zoom);
+    invert_zoom_action->setChecked(invert_zoom);
+
+    autoreload_action->setChecked(settings.value(AUTORELOAD_KEY, true).toBool());
+
+    bool draw_axes = settings.value(DRAW_AXES_KEY, false).toBool();
+    canvas->draw_axes(draw_axes);
+    axes_action->setChecked(draw_axes);
+
+    QString projection = settings.value(PROJECTION_KEY, "perspective").toString();
+    if(projection == "perspective"){
+        canvas->view_perspective(Canvas::P_PERSPECTIVE, false);
+        perspective_action->setChecked(true);
+    }else{
+        canvas->view_perspective(Canvas::P_ORTHOGRAPHIC, false);
+        orthographic_action->setChecked(true);
+    }
+
+    DrawMode draw_mode = (DrawMode)settings.value(DRAW_MODE_KEY, DRAWMODECOUNT).toInt();
+    
+    if(draw_mode >= DRAWMODECOUNT)
+    {
+        draw_mode = shaded;
+    }
+    canvas->set_drawMode(draw_mode);
+    QAction* (dm_acts[]) = {shaded_action, wireframe_action, surfaceangle_action};
+    dm_acts[draw_mode]->setChecked(true);
 }
 
 void Window::on_open()
@@ -217,40 +246,45 @@ void Window::on_projection(QAction* proj)
 {
     if (proj == perspective_action)
     {
-        canvas->view_perspective();
+        canvas->view_perspective(Canvas::P_PERSPECTIVE, true);
+        QSettings().setValue(PROJECTION_KEY, "perspective");
     }
     else
     {
-        canvas->view_orthographic();
+        canvas->view_perspective(Canvas::P_ORTHOGRAPHIC, true);
+        QSettings().setValue(PROJECTION_KEY, "orthographic");
     }
 }
 
-void Window::on_drawMode(QAction* mode)
+void Window::on_drawMode(QAction* act)
 {
-    if (mode == shaded_action)
+    DrawMode mode;
+    if (act == shaded_action)
     {
-        canvas->set_drawMode(shaded);
+        mode = shaded;
     }
-    else if (mode == wireframe_action)
+    else if (act == wireframe_action)
     {
-        canvas->set_drawMode(wireframe);
+        mode = wireframe;
     }
     else
     {
-        canvas->set_drawMode(surfaceangle);
+        mode = surfaceangle;
     }
+    canvas->set_drawMode(mode);
+    QSettings().setValue(DRAW_MODE_KEY, mode);
 }
 
 void Window::on_drawAxes(bool d)
 {
     canvas->draw_axes(d);
+    QSettings().setValue(DRAW_AXES_KEY, d);
 }
 
 void Window::on_invertZoom(bool d)
 {
     canvas->invert_zoom(d);
-    QSettings settings;
-    settings.setValue(INVERT_ZOOM_KEY, d);
+    QSettings().setValue(INVERT_ZOOM_KEY, d);
 }
 
 void Window::on_watched_change(const QString& filename)
@@ -267,6 +301,7 @@ void Window::on_autoreload_triggered(bool b)
     {
         on_reload();
     }
+    QSettings().setValue(AUTORELOAD_KEY, b);
 }
 
 void Window::on_clear_recent()
@@ -392,7 +427,6 @@ bool Window::load_stl(const QString& filename, bool is_reload)
                   this, &Window::set_watched);
         connect(loader, &Loader::loaded_file,
                   this, &Window::on_loaded);
-        autoreload_action->setEnabled(true);
         reload_action->setEnabled(true);
     }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -10,6 +10,7 @@ const QString Window::AUTORELOAD_KEY = "autoreload";
 const QString Window::DRAW_AXES_KEY = "drawAxes";
 const QString Window::PROJECTION_KEY = "projection";
 const QString Window::DRAW_MODE_KEY = "drawMode";
+const QString Window::WINDOW_GEOM_KEY = "windowGeometry";
 
 Window::Window(QWidget *parent) :
     QMainWindow(parent),
@@ -126,12 +127,10 @@ Window::Window(QWidget *parent) :
     QObject::connect(invert_zoom_action, &QAction::triggered,
             this, &Window::on_invertZoom);       
 
-    load_persist_settings();
-
     auto help_menu = menuBar()->addMenu("Help");
     help_menu->addAction(about_action);
 
-    resize(600, 400);
+    load_persist_settings();
 }
 
 void Window::load_persist_settings(){
@@ -164,6 +163,9 @@ void Window::load_persist_settings(){
     canvas->set_drawMode(draw_mode);
     QAction* (dm_acts[]) = {shaded_action, wireframe_action, surfaceangle_action};
     dm_acts[draw_mode]->setChecked(true);
+
+    resize(600, 400);
+    restoreGeometry(settings.value(WINDOW_GEOM_KEY).toByteArray());
 }
 
 void Window::on_open()
@@ -447,6 +449,18 @@ void Window::dragEnterEvent(QDragEnterEvent *event)
 void Window::dropEvent(QDropEvent *event)
 {
     load_stl(event->mimeData()->urls().front().toLocalFile());
+}
+
+void Window::resizeEvent(QResizeEvent *event)
+{
+    QSettings().setValue(WINDOW_GEOM_KEY, saveGeometry());
+    QWidget::resizeEvent(event);
+}
+
+void Window::moveEvent(QMoveEvent *event)
+{
+    QSettings().setValue(WINDOW_GEOM_KEY, saveGeometry());
+    QWidget::moveEvent(event);
 }
 
 void Window::sorted_insert(QStringList& list, const QCollator& collator, const QString& value)

--- a/src/window.h
+++ b/src/window.h
@@ -20,6 +20,8 @@ public:
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void moveEvent(QMoveEvent *event) override;
     void keyPressEvent(QKeyEvent* event) override;
 
 public slots:
@@ -78,6 +80,7 @@ private:
     const static QString DRAW_AXES_KEY;
     const static QString PROJECTION_KEY;
     const static QString DRAW_MODE_KEY;
+    const static QString WINDOW_GEOM_KEY;
 
     QString current_file;
     QString lookup_folder;

--- a/src/window.h
+++ b/src/window.h
@@ -49,6 +49,7 @@ private slots:
 
 private:
     void rebuild_recent_files();
+    void load_persist_settings();
     void sorted_insert(QStringList& list, const QCollator& collator, const QString& value);
     void build_folder_file_list();
     QPair<QString, QString> get_file_neighbors();
@@ -57,7 +58,7 @@ private:
     QAction* const about_action;
     QAction* const quit_action;
     QAction* const perspective_action;
-    QAction* const orthogonal_action;
+    QAction* const orthographic_action;
     QAction* const shaded_action;
     QAction* const wireframe_action;
     QAction* const surfaceangle_action;
@@ -73,6 +74,11 @@ private:
     const static int MAX_RECENT_FILES=8;
     const static QString RECENT_FILE_KEY;
     const static QString INVERT_ZOOM_KEY;
+    const static QString AUTORELOAD_KEY;
+    const static QString DRAW_AXES_KEY;
+    const static QString PROJECTION_KEY;
+    const static QString DRAW_MODE_KEY;
+
     QString current_file;
     QString lookup_folder;
     QStringList lookup_folder_files;


### PR DESCRIPTION
Addresses #77. Noteworthy facets of this change:

- 'Autoreload' is now always enabled. I assume that since it is a persistent setting, it makes sense to be able to configure it even if no model is loaded.
- `Canvas::view_perspective` and `::view_orthogonal` are now merged into a single function with the help of constants `Canvas::P_PERSPECTIVE` and `::P_ORTHOGRAPHIC`. I had to touch this code to avoid a perspective-warp animation while loading from persisted settings.
- Organization name is now 'fstl-app'. This should make it easier for users to find their configurations, since this repo is no longer under mkeeter.
- 'Orthogonal'/'Orthographic' name split unified under 'Orthographic'.

Here is an example configuration file:
```
[General]
autoreload=false
drawAxes=true
drawMode=2
invertZoom=true
projection=orthographic
recentFiles=/home/martin/test.stl, /home/martin/test2.stl
```

Please let me know if you have any feedback.