### PR TITLE
Fix STL file selection filter

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -180,8 +180,8 @@ void Window::load_persist_settings(){
 
 void Window::on_open()
 {
-    QString filename = QFileDialog::getOpenFileName(
-                this, "Load .stl file", QString(), "STL files (*.stl, *.STL)");
+    const QString filename = QFileDialog::getOpenFileName(
+                this, "Load .stl file", QString(), "STL files (*.stl *.STL)");
     if (!filename.isNull())
     {
         load_stl(filename);


### PR DESCRIPTION
On windows using the regex *.[sS][tT][lL] did not work and neither did QFileDialog::HideNameFilterDetails. Removing the comma, however, did.

Fixes #73
Fixes #86 