### PR TITLE
Add the option to reset or not the rotation when loading a new stl file.

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -22,7 +22,6 @@ Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
     styleFile.open( QFile::ReadOnly );
     setStyleSheet(styleFile.readAll());
     currentTransform = QMatrix4x4();
-    //currentTransform.setToIdentity();
     resetTransform();
 
     anim.setDuration(100);

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -22,7 +22,8 @@ Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
     styleFile.open( QFile::ReadOnly );
     setStyleSheet(styleFile.readAll());
     currentTransform = QMatrix4x4();
-    currentTransform.setToIdentity();
+    //currentTransform.setToIdentity();
+    resetTransform();
 
     anim.setDuration(100);
 }
@@ -67,6 +68,10 @@ void Canvas::invert_zoom(bool d)
     update();
 }
 
+void Canvas::setResetTransformOnLoad(bool d) {
+    resetTransformOnLoad = d;
+}
+
 void Canvas::resetTransform() {
     currentTransform.setToIdentity();
     // apply some rotations to define initial orientation
@@ -90,7 +95,9 @@ void Canvas::load_mesh(Mesh* m, bool is_reload)
 
         // Reset other camera parameters
         zoom = 1;
-        resetTransform();
+        if (resetTransformOnLoad) {
+            resetTransform();
+        }
     }
     meshInfo = QStringLiteral("Triangles: %1\nX: [%2, %3]\nY: [%4, %5]\nZ: [%6, %7]").arg(m->triCount());
     for(int dIdx = 0; dIdx < 3; dIdx++) meshInfo = meshInfo.arg(lower[dIdx]).arg(upper[dIdx]);

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -27,6 +27,7 @@ public:
     void draw_axes(bool d);
     void invert_zoom(bool d);
     void set_drawMode(enum DrawMode mode);
+    void setResetTransformOnLoad(bool d);
 
 public slots:
     void set_status(const QString& s);
@@ -75,6 +76,7 @@ private:
     enum DrawMode drawMode;
     bool drawAxes;
     bool invertZoom;
+    bool resetTransformOnLoad;
     Q_PROPERTY(float perspective MEMBER perspective WRITE set_perspective);
     QPropertyAnimation anim;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -11,6 +11,7 @@ const QString Window::DRAW_AXES_KEY = "drawAxes";
 const QString Window::PROJECTION_KEY = "projection";
 const QString Window::DRAW_MODE_KEY = "drawMode";
 const QString Window::WINDOW_GEOM_KEY = "windowGeometry";
+const QString Window::RESET_TRANSFORM_ON_LOAD_KEY = "resetTransformOnLoad";
 
 Window::Window(QWidget *parent) :
     QMainWindow(parent),
@@ -28,6 +29,7 @@ Window::Window(QWidget *parent) :
     autoreload_action(new QAction("Autoreload", this)),
     save_screenshot_action(new QAction("Save Screenshot", this)),
     hide_menuBar_action(new QAction("Hide Menu Bar", this)),
+    resetTransformOnLoadAction(new QAction("Reset rotation on load",this)),
     recent_files(new QMenu("Open recent", this)),
     recent_files_group(new QActionGroup(this)),
     recent_files_clear_action(new QAction("Clear recent files", this)),
@@ -131,6 +133,11 @@ Window::Window(QWidget *parent) :
     QObject::connect(invert_zoom_action, &QAction::triggered,
             this, &Window::on_invertZoom);       
 
+    view_menu->addAction(resetTransformOnLoadAction);
+    resetTransformOnLoadAction->setCheckable(true);
+    QObject::connect(resetTransformOnLoadAction, &QAction::triggered,
+            this, &Window::on_resetTransformOnLoad);
+
     view_menu->addAction(hide_menuBar_action);
     hide_menuBar_action->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C);
     hide_menuBar_action->setCheckable(true);
@@ -149,6 +156,10 @@ void Window::load_persist_settings(){
     bool invert_zoom = settings.value(INVERT_ZOOM_KEY, false).toBool();
     canvas->invert_zoom(invert_zoom);
     invert_zoom_action->setChecked(invert_zoom);
+
+    bool resetTransformOnLoad = settings.value(RESET_TRANSFORM_ON_LOAD_KEY, true).toBool();
+    canvas->setResetTransformOnLoad(resetTransformOnLoad);
+    resetTransformOnLoadAction->setChecked(resetTransformOnLoad);
 
     autoreload_action->setChecked(settings.value(AUTORELOAD_KEY, true).toBool());
 
@@ -298,6 +309,11 @@ void Window::on_invertZoom(bool d)
 {
     canvas->invert_zoom(d);
     QSettings().setValue(INVERT_ZOOM_KEY, d);
+}
+
+void Window::on_resetTransformOnLoad(bool d) {
+    canvas->setResetTransformOnLoad(d);
+    QSettings().setValue(RESET_TRANSFORM_ON_LOAD_KEY, d);
 }
 
 void Window::on_watched_change(const QString& filename)

--- a/src/window.h
+++ b/src/window.h
@@ -41,6 +41,7 @@ private slots:
     void on_drawMode(QAction* mode);
     void on_drawAxes(bool d);
     void on_invertZoom(bool d);
+    void on_resetTransformOnLoad(bool d);
     void on_watched_change(const QString& filename);
     void on_reload();
     void on_autoreload_triggered(bool r);
@@ -71,6 +72,7 @@ private:
     QAction* const autoreload_action;
     QAction* const save_screenshot_action;
     QAction* const hide_menuBar_action;
+    QAction* const resetTransformOnLoadAction;
 
     QMenu* const recent_files;
     QActionGroup* const recent_files_group;
@@ -83,6 +85,7 @@ private:
     const static QString PROJECTION_KEY;
     const static QString DRAW_MODE_KEY;
     const static QString WINDOW_GEOM_KEY;
+    const static QString RESET_TRANSFORM_ON_LOAD_KEY;
 
     QString current_file;
     QString lookup_folder;


### PR DESCRIPTION
Add an option "Reset rotation on load" in the View menu. It is set by default.
If set, the behavior is the same as before, that is the rotation of the object is reset when a new file is loaded.
If unset, then the actual rotation will be kept when reading a new file. This can be useful when exploring a directory containing files with same orientation.