### PR TITLE
Wait for the STL file size to stop changing.

### DIFF
--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -120,7 +120,7 @@ Mesh* Loader::load_stl()
     file_size = file.size();
     do {
         file_size_old = file_size;
-        usleep(100000);
+        QThread::usleep(100000);
         file_size = file.size();
     }
     while(file_size != file_size_old);

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -116,6 +116,15 @@ Mesh* Loader::load_stl()
         return NULL;
     }
 
+    qint64 file_size, file_size_old;
+    file_size = file.size();
+    do {
+        file_size_old = file_size;
+        usleep(100000);
+        file_size = file.size();
+    }
+    while(file_size != file_size_old);
+
     // First, try to read the stl as an ASCII file
     if (file.read(5) == "solid")
     {


### PR DESCRIPTION
Fixes #37.

It's the approach from #106 but using Qt only.

10 ms was still racy in my tests (writing STL from OpenSCAD), so I went with 100 ms.