### PR TITLE
Revert "wait to load the stl file until file size  does not change anymore (#106)"

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -4,9 +4,6 @@
 #include "canvas.h"
 #include "loader.h"
 
-#include <sys/stat.h>
-#include <thread>
-
 const QString Window::RECENT_FILE_KEY = "recentFiles";
 const QString Window::INVERT_ZOOM_KEY = "invertZoom";
 const QString Window::AUTORELOAD_KEY = "autoreload";
@@ -442,18 +439,6 @@ void Window::on_reload()
 bool Window::load_stl(const QString& filename, bool is_reload)
 {
     if (!open_action->isEnabled())  return false;
-
-    struct stat st;
-    int file_size, file_size_old;
-    QByteArray ba = filename.toLatin1();
-    stat(ba.data(), &st);
-    file_size = st.st_size;
-    do { // wait until file size does not change anymore within 10 ms
-        file_size_old = file_size;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        stat(ba.data(), &st);
-        file_size = st.st_size;
-    } while (file_size != file_size_old);
 
     canvas->set_status("Loading " + filename);
 


### PR DESCRIPTION
This reverts commit c4dd685d128b1d940db328f78276a09672671df3.

With #107 merged, we no longer need this duplicate code in `window.cpp`