### PR TITLE
Support standard Close shortcut

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -74,7 +74,8 @@ Window::Window(QWidget *parent) :
                      this, &Window::on_open);
     this->addAction(open_action);
 
-    quit_action->setShortcut(QKeySequence::Quit);
+    QList<QKeySequence> quitShortcuts = { QKeySequence::Quit, QKeySequence::Close };
+    quit_action->setShortcuts(quitShortcuts);
     QObject::connect(quit_action, &QAction::triggered,
                      this, &Window::close);
     this->addAction(quit_action);


### PR DESCRIPTION
This PR adds support for closing the current window with CTRL+W, the standard Close shortcut [as per Qt's docs](https://doc.qt.io/qt-6/qkeysequence.html#standard-shortcuts). The Quit shortcut (CTRL+Q) is kept as the primary choice shown in the menus.

Multiple shortcuts for the same menu action will only work if the underlying OS supports them. This has been tested on Linux but is expected to not work on, for example, Mac OS where the main shortcut will probably still be the only option available.