### PR TITLE
Add Viewpoint shortcuts and isometric view

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -88,19 +88,19 @@ void Canvas::view_anim(float v)
 
 void Canvas::common_view_change(enum ViewPoint c)
 {
+    if (c == centerview) {
+        scale = default_scale;
+        center = default_center;
+        zoom = 1;
+        update();
+        return;
+    }
+
     currentTransform.setToIdentity();
     currentTransform.rotate(180.0, QVector3D(0, 0, 1));
 
     switch (c)
     {
-    case centerview:
-        {
-            scale = default_scale;
-            center = default_center;
-            zoom = 1;
-        }
-        break;
-
     case topview:
         {
             currentTransform.rotate(180, QVector3D(1, 0, 0));

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -101,6 +101,13 @@ void Canvas::common_view_change(enum ViewPoint c)
 
     switch (c)
     {
+    case isoview:
+        {
+            currentTransform.rotate(90, QVector3D(1, 0, 0));
+            currentTransform.rotate(-45, QVector3D(0, 0, 1));
+            currentTransform.rotate(35.264, QVector3D(1, 1, 0));
+        }
+        break;
     case topview:
         {
             currentTransform.rotate(180, QVector3D(1, 0, 0));

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -10,7 +10,7 @@ class Mesh;
 class Backdrop;
 class Axis;
 
-enum ViewPoint {centerview, topview, bottomview, leftview, rightview, frontview, backview};
+enum ViewPoint {centerview, isoview, topview, bottomview, leftview, rightview, frontview, backview};
 enum DrawMode {shaded, wireframe, surfaceangle, meshlight, DRAWMODECOUNT};
 
 class Canvas : public QOpenGLWidget, protected QOpenGLFunctions

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -144,21 +144,28 @@ Window::Window(QWidget *parent) :
     drawModePrefs_action->setDisabled(true);
 
     const auto common_menu = view_menu->addMenu("Viewpoint");
-    common_menu->addAction(common_view_center_action);
     common_menu->addAction(common_view_top_action);
     common_menu->addAction(common_view_bottom_action);
-    common_menu->addAction(common_view_left_action);
-    common_menu->addAction(common_view_right_action);
     common_menu->addAction(common_view_front_action);
     common_menu->addAction(common_view_back_action);
+    common_menu->addAction(common_view_left_action);
+    common_menu->addAction(common_view_right_action);
+    common_menu->addAction(common_view_center_action);
     const auto common_views = new QActionGroup(common_menu);
-    common_views->addAction(common_view_center_action);
     common_views->addAction(common_view_top_action);
     common_views->addAction(common_view_bottom_action);
-    common_views->addAction(common_view_left_action);
-    common_views->addAction(common_view_right_action);
     common_views->addAction(common_view_front_action);
     common_views->addAction(common_view_back_action);
+    common_views->addAction(common_view_left_action);
+    common_views->addAction(common_view_right_action);
+    common_views->addAction(common_view_center_action);
+    common_view_top_action->setShortcut(Qt::Key_1);
+    common_view_bottom_action->setShortcut(Qt::Key_2);
+    common_view_front_action->setShortcut(Qt::Key_3);
+    common_view_back_action->setShortcut(Qt::Key_4);
+    common_view_left_action->setShortcut(Qt::Key_5);
+    common_view_right_action->setShortcut(Qt::Key_6);
+    common_view_center_action->setShortcut(Qt::Key_9);
     QObject::connect(common_views, &QActionGroup::triggered,
         this, &Window::on_common_view_change);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -21,6 +21,7 @@ Window::Window(QWidget *parent) :
     quit_action(new QAction("Quit", this)),
     perspective_action(new QAction("Perspective", this)),
     common_view_center_action(new QAction("Center the model", this)),
+    common_view_iso_action(new QAction("Isometric", this)),
     common_view_top_action(new QAction("Top", this)),
     common_view_bottom_action(new QAction("Bottom", this)),
     common_view_left_action(new QAction("Left", this)),
@@ -144,6 +145,7 @@ Window::Window(QWidget *parent) :
     drawModePrefs_action->setDisabled(true);
 
     const auto common_menu = view_menu->addMenu("Viewpoint");
+    common_menu->addAction(common_view_iso_action);
     common_menu->addAction(common_view_top_action);
     common_menu->addAction(common_view_bottom_action);
     common_menu->addAction(common_view_front_action);
@@ -152,6 +154,7 @@ Window::Window(QWidget *parent) :
     common_menu->addAction(common_view_right_action);
     common_menu->addAction(common_view_center_action);
     const auto common_views = new QActionGroup(common_menu);
+    common_views->addAction(common_view_iso_action);
     common_views->addAction(common_view_top_action);
     common_views->addAction(common_view_bottom_action);
     common_views->addAction(common_view_front_action);
@@ -159,6 +162,7 @@ Window::Window(QWidget *parent) :
     common_views->addAction(common_view_left_action);
     common_views->addAction(common_view_right_action);
     common_views->addAction(common_view_center_action);
+    common_view_iso_action->setShortcut(Qt::Key_0);
     common_view_top_action->setShortcut(Qt::Key_1);
     common_view_bottom_action->setShortcut(Qt::Key_2);
     common_view_front_action->setShortcut(Qt::Key_3);
@@ -506,6 +510,7 @@ void Window::on_reload()
 void Window::on_common_view_change(QAction* common)
 {
   if (common == common_view_center_action) canvas->common_view_change(centerview);
+  if (common == common_view_iso_action) canvas->common_view_change(isoview);
   if (common == common_view_top_action) canvas->common_view_change(topview);
   if (common == common_view_bottom_action) canvas->common_view_change(bottomview);
   if (common == common_view_left_action) canvas->common_view_change(leftview);

--- a/src/window.h
+++ b/src/window.h
@@ -67,6 +67,7 @@ private:
     QAction* const quit_action;
     QAction* const perspective_action;
     QAction* const common_view_center_action;
+    QAction* const common_view_iso_action;
     QAction* const common_view_top_action;
     QAction* const common_view_bottom_action;
     QAction* const common_view_left_action;


### PR DESCRIPTION
This adds three commits, making these changes:

 1. Do not reset rotation on 'Center the model'. This used to also set the rotation to the 'Bottom' viewpoint, which is not always desirable. Now it only resets the scale, center and zoom to the default values.
 2. Add shortcuts to Viewpoint submenu. The shortcuts are copied from PrusaSlicer, which is likely to be familiar to fstl users.
 3. Add isometric view.