### PR TITLE
Feature/open external

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -9,16 +9,16 @@ App::App(int& argc, char *argv[]) :
     QApplication(argc, argv), window(new Window())
 {
     if (argc > 1) {
-		QString filename = argv[1];
-		if (filename.startsWith("~")) {
-			filename.replace(0, 1, QDir::homePath());
-		}
-		window->load_stl(filename);
-	}
+        QString filename = argv[1];
+        if (filename.startsWith("~")) {
+            filename.replace(0, 1, QDir::homePath());
+        }
+        window->load_stl(filename);
+    }
     else
-	{
-		window->load_stl(":gl/sphere.stl");
-	}
+    {
+        window->load_stl(":gl/sphere.stl");
+    }
     window->show();
 }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,5 +1,6 @@
 #include <QDebug>
 #include <QFileOpenEvent>
+#include <QDir>
 
 #include "app.h"
 #include "window.h"
@@ -7,10 +8,17 @@
 App::App(int& argc, char *argv[]) :
     QApplication(argc, argv), window(new Window())
 {
-    if (argc > 1)
-        window->load_stl(argv[1]);
+    if (argc > 1) {
+		QString filename = argv[1];
+		if (filename.startsWith("~")) {
+			filename.replace(0, 1, QDir::homePath());
+		}
+		window->load_stl(filename);
+	}
     else
-        window->load_stl(":gl/sphere.stl");
+	{
+		window->load_stl(":gl/sphere.stl");
+	}
     window->show();
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -242,10 +242,14 @@ void Window::load_persist_settings(){
         orthographic_action->setChecked(true);
     }
 
-	QString fullPath = QStandardPaths::findExecutable(settings.value(OPEN_EXTERNAL_KEY, "cura5").toString());
-	QString displayName = fullPath.mid(fullPath.lastIndexOf(QDir::separator()) + 1);
+	QString path = settings.value(OPEN_EXTERNAL_KEY, "cura5").toString();
+	if (!QDir::isAbsolutePath(path))
+	{
+		path = QStandardPaths::findExecutable(path);
+	}
+	QString displayName = path.mid(path.lastIndexOf(QDir::separator()) + 1);
 	open_external_action->setText("Open with " + displayName);
-	open_external_action->setData(fullPath);
+	open_external_action->setData(path);
 
     DrawMode draw_mode = (DrawMode)settings.value(DRAW_MODE_KEY, DRAWMODECOUNT).toInt();
     

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -18,7 +18,7 @@ const QString Window::RESET_TRANSFORM_ON_LOAD_KEY = "resetTransformOnLoad";
 Window::Window(QWidget *parent) :
     QMainWindow(parent),
     open_action(new QAction("Open", this)),
-	open_external_action(new QAction("Open with", this)),
+    open_external_action(new QAction("Open with", this)),
     about_action(new QAction("About", this)),
     quit_action(new QAction("Quit", this)),
     perspective_action(new QAction("Perspective", this)),
@@ -77,10 +77,10 @@ Window::Window(QWidget *parent) :
                      this, &Window::on_open);
     this->addAction(open_action);
 
-	open_external_action->setShortcut(QKeySequence::Open);
-	QObject::connect(open_external_action, &QAction::triggered, this, &Window::on_open_external);
-	this->addAction(open_external_action);
-	open_external_action->setShortcut(QKeySequence(Qt::ALT + Qt::Key_S));
+    open_external_action->setShortcut(QKeySequence::Open);
+    QObject::connect(open_external_action, &QAction::triggered, this, &Window::on_open_external);
+    this->addAction(open_external_action);
+    open_external_action->setShortcut(QKeySequence(Qt::ALT + Qt::Key_S));
 
     QList<QKeySequence> quitShortcuts = { QKeySequence::Quit, QKeySequence::Close };
     quit_action->setShortcuts(quitShortcuts);
@@ -113,7 +113,7 @@ Window::Window(QWidget *parent) :
 
     const auto file_menu = menuBar()->addMenu("File");
     file_menu->addAction(open_action);
-	file_menu->addAction(open_external_action);
+    file_menu->addAction(open_external_action);
     file_menu->addMenu(recent_files);
     file_menu->addSeparator();
     file_menu->addAction(reload_action);
@@ -242,14 +242,14 @@ void Window::load_persist_settings(){
         orthographic_action->setChecked(true);
     }
 
-	QString path = settings.value(OPEN_EXTERNAL_KEY, "cura5").toString();
-	if (!QDir::isAbsolutePath(path))
-	{
-		path = QStandardPaths::findExecutable(path);
-	}
-	QString displayName = path.mid(path.lastIndexOf(QDir::separator()) + 1);
-	open_external_action->setText("Open with " + displayName);
-	open_external_action->setData(path);
+    QString path = settings.value(OPEN_EXTERNAL_KEY, "").toString();
+    if (!QDir::isAbsolutePath(path) && !path.isEmpty())
+    {
+        path = QStandardPaths::findExecutable(path);
+    }
+    QString displayName = path.mid(path.lastIndexOf(QDir::separator()) + 1);
+    open_external_action->setText("Open with " + displayName);
+    open_external_action->setData(path);
 
     DrawMode draw_mode = (DrawMode)settings.value(DRAW_MODE_KEY, DRAWMODECOUNT).toInt();
     
@@ -288,10 +288,10 @@ void Window::on_open()
 
 void Window::on_open_external() const
 {
-	if (current_file.isEmpty())
-	{
-		return;
-	}
+    if (current_file.isEmpty())
+    {
+        return;
+    }
 
 	QString program = open_external_action->data().toString();
 	QProcess::startDetached(program, QStringList(current_file));

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -293,8 +293,20 @@ void Window::on_open_external() const
         return;
     }
 
-	QString program = open_external_action->data().toString();
-	QProcess::startDetached(program, QStringList(current_file));
+
+    QString program = open_external_action->data().toString();
+    if (program.isEmpty()) {
+        program = QFileDialog::getOpenFileName((QWidget*) this, "Select program to open with", QDir::rootPath());
+        if (!program.isEmpty()) {
+            QSettings settings;
+            settings.setValue(OPEN_EXTERNAL_KEY, program);
+            QString displayName = program.mid(program.lastIndexOf(QDir::separator()) + 1);
+            open_external_action->setText("Open with " + displayName);
+            open_external_action->setData(program);
+        }
+    }
+
+    QProcess::startDetached(program, QStringList(current_file));
 }
 
 void Window::on_about()

--- a/src/window.h
+++ b/src/window.h
@@ -27,7 +27,7 @@ protected:
 
 public slots:
     void on_open();
-	void on_open_external() const;
+    void on_open_external() const;
     void on_about();
     void on_bad_stl();
     void on_empty_mesh();
@@ -64,7 +64,7 @@ private:
     QPair<QString, QString> get_file_neighbors();
 
     QAction* const open_action;
-	QAction* const open_external_action;
+    QAction* const open_external_action;
     QAction* const about_action;
     QAction* const quit_action;
     QAction* const perspective_action;
@@ -95,7 +95,7 @@ private:
     QActionGroup* const recent_files_group;
     QAction* const recent_files_clear_action;
     const static int MAX_RECENT_FILES=8;
-	static const QString OPEN_EXTERNAL_KEY;
+    static const QString OPEN_EXTERNAL_KEY;
     const static QString RECENT_FILE_KEY;
     const static QString INVERT_ZOOM_KEY;
     const static QString AUTORELOAD_KEY;

--- a/src/window.h
+++ b/src/window.h
@@ -27,6 +27,7 @@ protected:
 
 public slots:
     void on_open();
+	void on_open_external() const;
     void on_about();
     void on_bad_stl();
     void on_empty_mesh();
@@ -63,6 +64,7 @@ private:
     QPair<QString, QString> get_file_neighbors();
 
     QAction* const open_action;
+	QAction* const open_external_action;
     QAction* const about_action;
     QAction* const quit_action;
     QAction* const perspective_action;
@@ -93,6 +95,7 @@ private:
     QActionGroup* const recent_files_group;
     QAction* const recent_files_clear_action;
     const static int MAX_RECENT_FILES=8;
+	static const QString OPEN_EXTERNAL_KEY;
     const static QString RECENT_FILE_KEY;
     const static QString INVERT_ZOOM_KEY;
     const static QString AUTORELOAD_KEY;


### PR DESCRIPTION
Might be useful for someone that wants to open they're viewing in a slicer for immediate printing.

Added a simple .conf file option to specify an external command or an absolute path to a program to open the current file with ALT+S shortcut.
Added a ~ expand to filename provided via command line arguments.