### PR TITLE
fix: opening files with cyrillic symbols from command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Original Project Author: Matt Keeter Copyright 2014-2024
 # Author: Paul Tsouchlos Copyright 2017-2024
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(fstl)
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -9,7 +9,8 @@ App::App(int& argc, char *argv[]) :
     QApplication(argc, argv), window(new Window())
 {
     if (argc > 1) {
-        QString filename = argv[1];
+        const auto args = QCoreApplication::arguments();
+        QString filename = args.at(1);
         if (filename.startsWith("~")) {
             filename.replace(0, 1, QDir::homePath());
         }


### PR DESCRIPTION
## Changes

- Minimum CMake version bumped to `3.5` to allow for building with CMake 4.x
- Fixed bug where files with Cyrillic symbols could not be opened when passed as CLI args (`fstl "тестовая модель.stl"`)

Fixes #122 